### PR TITLE
Фикс краша после перезагрузки бандла на андоиде.

### DIFF
--- a/android/src/main/java/ru/vvdev/yamap/RNYamapModule.java
+++ b/android/src/main/java/ru/vvdev/yamap/RNYamapModule.java
@@ -3,6 +3,7 @@ package ru.vvdev.yamap;
 import androidx.annotation.NonNull;
 
 import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -45,14 +46,30 @@ public class RNYamapModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void init(final String apiKey) {
+    public void init(final String apiKey, final Promise promise) {
         runOnUiThread(new Thread(new Runnable() {
             @Override
             public void run() {
-                MapKitFactory.setApiKey(apiKey);
-                MapKitFactory.initialize(reactContext);
-                TransportFactory.initialize(reactContext);
-                MapKitFactory.getInstance().onStart();
+                Error apiKeyError = null;
+                try {
+                    // In case when android application reloads during development
+                    // MapKitFactory is already initialized
+                    // And setting api key leads to crash
+                    try {
+                        MapKitFactory.setApiKey(apiKey);
+                    } catch (Error error) {
+                        apiKeyError = error;
+                    }
+                    MapKitFactory.initialize(reactContext);
+                    TransportFactory.initialize(reactContext);
+                    MapKitFactory.getInstance().onStart();
+                    promise.resolve(null);
+                } catch (Error error) {
+                    if(apiKeyError != null) {
+                        promise.reject(apiKeyError);
+                    }
+                    promise.reject(error);
+                }
             }
         }));
     }

--- a/android/src/main/java/ru/vvdev/yamap/RNYamapModule.java
+++ b/android/src/main/java/ru/vvdev/yamap/RNYamapModule.java
@@ -67,6 +67,7 @@ public class RNYamapModule extends ReactContextBaseJavaModule {
                 } catch (Error error) {
                     if(apiKeyError != null) {
                         promise.reject(apiKeyError);
+                        return;
                     }
                     promise.reject(error);
                 }

--- a/android/src/main/java/ru/vvdev/yamap/RNYamapModule.java
+++ b/android/src/main/java/ru/vvdev/yamap/RNYamapModule.java
@@ -50,26 +50,26 @@ public class RNYamapModule extends ReactContextBaseJavaModule {
         runOnUiThread(new Thread(new Runnable() {
             @Override
             public void run() {
-                Error apiKeyError = null;
+                Exception apiKeyException = null;
                 try {
                     // In case when android application reloads during development
                     // MapKitFactory is already initialized
                     // And setting api key leads to crash
                     try {
                         MapKitFactory.setApiKey(apiKey);
-                    } catch (Error error) {
-                        apiKeyError = error;
+                    } catch (Exception exception) {
+                        apiKeyException = exception;
                     }
                     MapKitFactory.initialize(reactContext);
                     TransportFactory.initialize(reactContext);
                     MapKitFactory.getInstance().onStart();
                     promise.resolve(null);
-                } catch (Error error) {
-                    if(apiKeyError != null) {
-                        promise.reject(apiKeyError);
+                } catch (Exception exception) {
+                    if(apiKeyException != null) {
+                        promise.reject(apiKeyException);
                         return;
                     }
-                    promise.reject(error);
+                    promise.reject(exception);
                 }
             }
         }));

--- a/android/src/main/java/ru/vvdev/yamap/RNYamapModule.java
+++ b/android/src/main/java/ru/vvdev/yamap/RNYamapModule.java
@@ -50,14 +50,14 @@ public class RNYamapModule extends ReactContextBaseJavaModule {
         runOnUiThread(new Thread(new Runnable() {
             @Override
             public void run() {
-                Exception apiKeyException = null;
+                Throwable apiKeyException = null;
                 try {
                     // In case when android application reloads during development
                     // MapKitFactory is already initialized
                     // And setting api key leads to crash
                     try {
                         MapKitFactory.setApiKey(apiKey);
-                    } catch (Exception exception) {
+                    } catch (Throwable exception) {
                         apiKeyException = exception;
                     }
                     MapKitFactory.initialize(reactContext);

--- a/ios/RNYamap.m
+++ b/ios/RNYamap.m
@@ -27,8 +27,15 @@ static NSString * _selectedMarkerIcon;
     return dispatch_get_main_queue();
 }
 
-RCT_EXPORT_METHOD(init: (NSString *) apiKey) {
-    [self initWithKey: apiKey];
+RCT_EXPORT_METHOD(init: (NSString *) apiKey
+              resolver:(RCTPromiseResolveBlock)resolve
+              rejecter:(RCTPromiseRejectBlock)reject) {
+    @try {
+        [self initWithKey: apiKey];
+        resolve(nil);
+    } @catch(id anException) {
+        reject(@"ERROR", @"Error with initiating YMKMapKit.", nil);
+    }
 }
 
 RCT_EXPORT_METHOD(setLocale: (NSString *) locale successCallback:(RCTResponseSenderBlock)successCb errorCallback:(RCTResponseSenderBlock) errorCb) {

--- a/ios/RNYamap.m
+++ b/ios/RNYamap.m
@@ -33,8 +33,12 @@ RCT_EXPORT_METHOD(init: (NSString *) apiKey
     @try {
         [self initWithKey: apiKey];
         resolve(nil);
-    } @catch(id anException) {
-        reject(@"ERROR", @"Error with initiating YMKMapKit.", nil);
+    } @catch (NSException *exception) {
+        NSError *error = nil; 
+        if (exception.userInfo.count > 0) {
+            error = [NSError errorWithDomain:NSCocoaErrorDomain code:0 userInfo:exception.userInfo];
+        } 
+        rejecter(exception.name, exception.reason ?: @"Error initiating YMKMapKit", error);
     }
 }
 

--- a/ios/RNYamap.m
+++ b/ios/RNYamap.m
@@ -38,7 +38,7 @@ RCT_EXPORT_METHOD(init: (NSString *) apiKey
         if (exception.userInfo.count > 0) {
             error = [NSError errorWithDomain:NSCocoaErrorDomain code:0 userInfo:exception.userInfo];
         } 
-        rejecter(exception.name, exception.reason ?: @"Error initiating YMKMapKit", error);
+        reject(exception.name, exception.reason ?: @"Error initiating YMKMapKit", error);
     }
 }
 

--- a/ios/YamapSuggests.m
+++ b/ios/YamapSuggests.m
@@ -86,7 +86,7 @@ RCT_EXPORT_METHOD(suggest:(nonnull NSString*) searchQuery
     }
 })
 
-RCT_EXPORT_METHOD(resetSuggest: (NSString*) ususedParam
+RCT_EXPORT_METHOD(reset: (NSString*) ususedParam
                       resolver:(RCTPromiseResolveBlock) resolve
                       rejecter:(RCTPromiseRejectBlock) reject {
     @try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-yamap",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Yandex.MapKit and Yandex.Geocoder for react-native",
   "main": "build/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Yandex.MapKit and Yandex.Geocoder for react-native",
   "main": "build/index.js",
   "scripts": {
-    "prepublishOnly": "rm -rf build && tsc",
+    "prepare": "rm -rf build && tsc",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "homepage": "https://github.com/volga-volga/react-native-yamap",

--- a/src/components/Yamap.tsx
+++ b/src/components/Yamap.tsx
@@ -55,8 +55,8 @@ export class YaMap extends React.Component<YaMapProps> {
     'funicular',
   ];
 
-  public static init(apiKey: string) {
-    NativeYamapModule.init(apiKey);
+  public static init(apiKey: string): Promise<void> {
+    return NativeYamapModule.init(apiKey);
   }
 
   public static setLocale(locale: string): Promise<void> {


### PR DESCRIPTION
**Проблема**
При перезагрузки бандла приложения RN падает с ошибкой 
![image](https://user-images.githubusercontent.com/17254979/145600210-e1a7906f-7458-4318-b085-13afe636f1d2.png)



**Описание**
Не знаю точно чем вызвана проблема, но думаю что дело в том что на андроиде при перезагрузке бандла не сбрасываются ключи, которые были выставлены нативным методом.С какого-то момента это стало вызывать краш.

**Решение**
Обложил try catch и поменял тип инициализации с синхронной функции на асинхронную. 

**Связанные ишью**
https://github.com/volga-volga/react-native-yamap/issues/78