### PR TITLE
Revert suggest fix on iOS.

### DIFF
--- a/android/src/main/java/ru/vvdev/yamap/suggest/RNYandexSuggestModule.java
+++ b/android/src/main/java/ru/vvdev/yamap/suggest/RNYandexSuggestModule.java
@@ -60,11 +60,12 @@ public class RNYandexSuggestModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    void reset() {
+    void reset(final Callback successCb, final Callback errorCb) {
         runOnUiThread(new Runnable() {
             @Override
             public void run() {
                 getSuggestClient(getReactApplicationContext()).resetSuggest();
+                successCb.invoke(null);
             }
         });
     }

--- a/ios/YamapSuggests.m
+++ b/ios/YamapSuggests.m
@@ -86,17 +86,16 @@ RCT_EXPORT_METHOD(suggest:(nonnull NSString*) searchQuery
     }
 })
 
-RCT_EXPORT_METHOD(reset: (NSString*) ususedParam
-                      resolver:(RCTPromiseResolveBlock) resolve
-                      rejecter:(RCTPromiseRejectBlock) reject {
+RCT_EXPORT_METHOD(reset:(RCTResponseSenderBlock) successCb 
+          errorCallback:(RCTResponseSenderBlock) errorCb {
     @try {
         if (suggestClient) {
             [suggestClient reset];
         }
-        resolve(@[]);
+        successCb(@[]);
     }
     @catch( NSException *error ) {
-        reject(@"ERROR", @"Error during reset suggestions", nil);
+        errorCb(@"ERROR", @"Error during reset suggestions", nil);
     }
 })
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-yamap",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "Yandex.MapKit and Yandex.Geocoder for react-native",
   "main": "build/index.js",
   "scripts": {

--- a/src/Suggest.ts
+++ b/src/Suggest.ts
@@ -28,7 +28,7 @@ const suggestWithCoords: SuggestWithCoordsFetcher = async (query) => {
 };
 
 type SuggestResetter = () => Promise<void>;
-const reset: SuggestResetter = () => YamapSuggests.reset();
+const reset: SuggestResetter = () => YamapSuggests.reset('');
 //  Original uri format for the MapKit 4.0.0 ymapsbm1://geo?ll=39.957371%2C48.306156&spn=0.001000%2C0.001000&text=%D0%A0%D0%BE%D1%81%D1%81%D0%B8%D1%8F%2C%20%D0%A0%D0%BE%D1%81%D1%82%D0%BE%D0%B2%D1%81%D0%BA%D0%B0%D1%8F%20%D0%BE%D0%B1%D0%BB%D0%B0%D1%81%D1%82%D1%8C%2C%20%D0%94%D0%BE%D0%BD%D0%B5%D1%86%D0%BA%2C%20%D1%83%D0%BB%D0%B8%D1%86%D0%B0%20%D0%9C%D0%B8%D0%BA%D0%BE%D1%8F%D0%BD%D0%B0%2C%2012
 // Decoded uri format ymapsbm1://geo?ll=39.957371,48.306156&spn=0.001000,0.001000&text=Россия, Ростовская область, Донецк, улица Микояна, 12
 type LatLonGetter = (suggest: YamapSuggest) => YamapCoords | undefined;

--- a/src/Suggest.ts
+++ b/src/Suggest.ts
@@ -28,7 +28,7 @@ const suggestWithCoords: SuggestWithCoordsFetcher = async (query) => {
 };
 
 type SuggestResetter = () => Promise<void>;
-const reset: SuggestResetter = () => YamapSuggests.reset('');
+const reset: SuggestResetter = () => new Promise((resolve, reject) => YamapSuggests.reset(resolve, reject));
 //  Original uri format for the MapKit 4.0.0 ymapsbm1://geo?ll=39.957371%2C48.306156&spn=0.001000%2C0.001000&text=%D0%A0%D0%BE%D1%81%D1%81%D0%B8%D1%8F%2C%20%D0%A0%D0%BE%D1%81%D1%82%D0%BE%D0%B2%D1%81%D0%BA%D0%B0%D1%8F%20%D0%BE%D0%B1%D0%BB%D0%B0%D1%81%D1%82%D1%8C%2C%20%D0%94%D0%BE%D0%BD%D0%B5%D1%86%D0%BA%2C%20%D1%83%D0%BB%D0%B8%D1%86%D0%B0%20%D0%9C%D0%B8%D0%BA%D0%BE%D1%8F%D0%BD%D0%B0%2C%2012
 // Decoded uri format ymapsbm1://geo?ll=39.957371,48.306156&spn=0.001000,0.001000&text=Россия, Ростовская область, Донецк, улица Микояна, 12
 type LatLonGetter = (suggest: YamapSuggest) => YamapCoords | undefined;


### PR DESCRIPTION
В прошлом ПР хотел пофиксить резет саггестов, получилось неудачно. Попробовал с ходу быстро нормально пофиксить - понял, что придется делать релиз андроида, плюс не хочется здесь закапываться пока в проде баг. Поэтому откатываю до предыдущего состояния функции reset, при котором она на самом деле вообще не вызывается 