### PR TITLE
Revert reset function fix on iOS.

### DIFF
--- a/ios/YamapSuggests.m
+++ b/ios/YamapSuggests.m
@@ -86,7 +86,7 @@ RCT_EXPORT_METHOD(suggest:(nonnull NSString*) searchQuery
     }
 })
 
-RCT_EXPORT_METHOD(reset: (NSString*) ususedParam
+RCT_EXPORT_METHOD(resetSuggest: (NSString*) ususedParam
                       resolver:(RCTPromiseResolveBlock) resolve
                       rejecter:(RCTPromiseRejectBlock) reject {
     @try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-yamap",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "Yandex.MapKit and Yandex.Geocoder for react-native",
   "main": "build/index.js",
   "scripts": {


### PR DESCRIPTION
В прошлом ПР хотел пофиксить резет саггестов, получилось неудачно. Попробовал с ходу быстро нормально пофиксить - понял, что придется делать релиз андроида, плюс не хочется здесь закапываться пока в проде баг. Поэтому откатываю до предыдущего состояния функции reset, при котором она на самом деле вообще не вызывается